### PR TITLE
Changes to work with 115th CD data

### DIFF
--- a/process.js
+++ b/process.js
@@ -13,7 +13,7 @@ var geojson = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
 // congressional district --- filter these out
 
 var filtered = geojson.features.filter(function(d) {
-  return d.properties['CD114FP'] !== 'ZZ' ? true : false;
+  return d.properties['CD115FP'] !== 'ZZ' ? true : false;
 });
 var districts = { 'type': 'FeatureCollection', 'features': filtered };
 
@@ -49,10 +49,10 @@ colored.features.map(function(d) {
   var pt = turf.point([parseFloat(d.properties['INTPTLON']), parseFloat(d.properties['INTPTLAT'])]);
 
   // Get the district number in two-digit form ("00" (for at-large
-  // districts), "01", "02", ...). The Census data's CD114FP field
+  // districts), "01", "02", ...). The Census data's CD115FP field
   // holds it in this format. Except for the island territories
   // which have "98", but are just at-large and should be "00".
-  var number = d.properties['CD114FP'];
+  var number = d.properties['CD115FP'];
   if (number == "98")
     number = "00";
 

--- a/upload.js
+++ b/upload.js
@@ -6,8 +6,8 @@ var districtsFile = process.argv[2],
     user = process.env.MAPBOX_USERNAME,
     accessToken = process.env.MAPBOX_WRITE_SCOPE_ACCESS_TOKEN;
 
-var tileset_id = user + ".cd-114-2015"; // max 32 characters (including "-labels" added below), only one period
-var tileset_name = "US_Congressional_Districts_114th_2015"; // max 64 characters (including "_Labels" added below) no spaces
+var tileset_id = user + ".cd-115-2016"; // max 32 characters (including "-labels" added below), only one period
+var tileset_name = "US_Congressional_Districts_115th_2016"; // max 64 characters (including "_Labels" added below) no spaces
 
 var client = new MapboxClient(accessToken);
 


### PR DESCRIPTION
Minor changes to make these scripts work with 115th Congressional district boundaries. These scripts should probably be modified to work with all via command line option.